### PR TITLE
Added default types and the possibility to pass list types

### DIFF
--- a/lib/simple_ttl.ex
+++ b/lib/simple_ttl.ex
@@ -1,6 +1,5 @@
 defmodule SimpleTTL do
   use GenServer
-  require Logger
 
   @time_unit :milliseconds
   @default_types [:set, :public, :named_table]

--- a/lib/simple_ttl.ex
+++ b/lib/simple_ttl.ex
@@ -2,7 +2,7 @@ defmodule SimpleTTL do
   use GenServer
 
   @time_unit :milliseconds
-  @default_types [:public, :named_table]
+  @default_types [:set, :public, :named_table]
   @forbidden_types [:protected, :private]
 
   def start_link(table, ttl, check_interval, type \\ []) do

--- a/lib/simple_ttl.ex
+++ b/lib/simple_ttl.ex
@@ -5,7 +5,7 @@ defmodule SimpleTTL do
   @default_types [:public, :named_table]
   @forbidden_types [:protected, :private]
 
-  def start_link(table, ttl, check_interval, type \\ :set) do
+  def start_link(table, ttl, check_interval, type \\ []) do
     GenServer.start_link(
       __MODULE__,
       %{table: table, ttl: ttl, check_interval: check_interval, type: type},
@@ -16,15 +16,10 @@ defmodule SimpleTTL do
   def init(old_args) do
     {type, args} = Map.pop(old_args, :type)
 
-    table_types =
-      case type do
-        [types] ->
-          (types ++ @default_types)
-          |> Enum.uniq()
-
-        type ->
-          [type]
-      end
+    table_types = \
+      types
+      ++ @default_types
+      |> Enum.uniq()
       |> List.flatten()
       |> Enum.reject(fn type -> type in @forbidden_types end)
 


### PR DESCRIPTION
Now you can pass `[:set, :public, :named_table]` as types or one single atom for the table creation type.

Appart from that we now have default types.